### PR TITLE
Fix missing product stats

### DIFF
--- a/product-feed-evaluator/feed_parser.py
+++ b/product-feed-evaluator/feed_parser.py
@@ -36,6 +36,18 @@ class FeedParser:
             
             # Handle both RSS and Atom feeds
             items = root.findall('.//item') or root.findall('.//entry')
+
+            # Fallback: if the root itself is a single item/entry node
+            if not items:
+                root_tag = root.tag
+                if '}' in root_tag:
+                    root_local = root_tag.split('}', 1)[1]
+                elif ':' in root_tag:
+                    root_local = root_tag.split(':', 1)[1]
+                else:
+                    root_local = root_tag
+                if root_local in ("item", "entry"):
+                    items = [root]
             
             for item in items:
                 product = self._extract_product_data(item)


### PR DESCRIPTION
Add fallback to XML parser to correctly process single-item feeds.

Previously, the parser expected a root element containing multiple `<item>` or `<entry>` tags. This change allows it to parse XML where a single `<item>` or `<entry>` is the root, ensuring quick stats for fields like Brand, Price, and Availability are displayed.

---
<a href="https://cursor.com/background-agent?bcId=bc-c9275ad8-acda-4e63-b2ba-99f00bcac6fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c9275ad8-acda-4e63-b2ba-99f00bcac6fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

