### PR TITLE
Remove api key requirement for field viewing

### DIFF
--- a/product-feed-evaluator/app.py
+++ b/product-feed-evaluator/app.py
@@ -44,8 +44,7 @@ def main():
         )
         
         if not api_key:
-            st.error("Please enter your OpenAI API key to continue.")
-            return
+            st.info("Optional: Enter your OpenAI API key to enable AI evaluation. You can still configure and load feeds without it.")
         
         # Model selection
         model = st.selectbox(
@@ -194,7 +193,8 @@ def main():
     
     # Process button
     if xml_content and selected_fields:
-        if st.button("🚀 Start Evaluation", disabled=st.session_state.processing):
+        start_button_disabled = st.session_state.processing or not api_key
+        if st.button("🚀 Start Evaluation", disabled=start_button_disabled):
             st.session_state.processing = True
             
             try:


### PR DESCRIPTION
Allow viewing and configuring feeds without an API key by removing the early return and disabling the 'Start Evaluation' button until a key is provided.

Previously, the entire UI was blocked until an API key was entered, preventing users from even seeing or setting up feed configurations. This change allows users to prepare their evaluation setup before providing the key.

---
<a href="https://cursor.com/background-agent?bcId=bc-21c41978-df06-4dd8-a89b-2649203621cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-21c41978-df06-4dd8-a89b-2649203621cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

