### PR TITLE
Fix prompt module import error

### DIFF
--- a/product-feed-evaluator/app.py
+++ b/product-feed-evaluator/app.py
@@ -23,7 +23,7 @@ from typing import Any, Dict, List, Tuple, Callable, Optional
 
 import pandas as pd
 
-from prompt import (
+from prompts import (
     QUESTION_GENERATION_PROMPT,
     QUESTION_QA_PROMPT,
     ANSWER_JUDGEMENT_PROMPT,


### PR DESCRIPTION
Fix `ModuleNotFoundError` by correcting the import statement from `prompt` to `prompts` in `app.py`.

---
<a href="https://cursor.com/background-agent?bcId=bc-e4ed36f3-36d5-4d01-8d46-96c6ca56abac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e4ed36f3-36d5-4d01-8d46-96c6ca56abac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

