### PR TITLE
Debug judgements column question error

### DIFF
--- a/product-feed-evaluator/prompts.py
+++ b/product-feed-evaluator/prompts.py
@@ -36,7 +36,7 @@ Rules:
 
 Return ONLY a JSON array of objects with this schema:
 [
-  { "question": string, "taxonomy": string }
+  {{ "question": string, "taxonomy": string }}
 ]
 
 CONTEXT:
@@ -53,7 +53,7 @@ QUESTION_QA_PROMPT = """System: You are a ruthless editor. You normalize, dedupe
 User:
 You are given:
 A) product summary (below)
-B) candidate questions (JSON array of {question, taxonomy})
+B) candidate questions (JSON array of {{question, taxonomy}})
 C) max_n = {N}
 
 Tasks:
@@ -67,7 +67,7 @@ Tasks:
 
 Return ONLY a JSON array with this schema:
 [
-  { "question": string, "taxonomy": string, "required": boolean }
+  {{ "question": string, "taxonomy": string, "required": boolean }}
 ]
 
 CONTEXT:
@@ -86,13 +86,13 @@ ANSWER_JUDGEMENT_PROMPT = """System: You strictly judge if the SUMMARY answers e
 
 User:
 For each question, output an object:
-{
+{{
   "question": str,
   "taxonomy": str,
   "required": boolean,
   "verdict": "yes"|"partial"|"no",
   "reason": str  // <= 16 words; if verdict is "yes", quote the exact supporting phrase
-}
+}}
 
 Verdict rules:
 - "yes": explicit, unambiguous answer with units/specs if applicable (quote brief phrase).


### PR DESCRIPTION
Escape literal curly braces in prompt templates to prevent `KeyError` during string formatting.

Unescaped curly braces in JSON examples within the prompts were being treated as `str.format` placeholders, leading to a `KeyError` for "question" and causing the `judgements` column to return error objects instead of valid data.

---
<a href="https://cursor.com/background-agent?bcId=bc-d2bb6e90-a0fc-4198-957a-af0a742a14a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d2bb6e90-a0fc-4198-957a-af0a742a14a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

